### PR TITLE
Remove dependency from neo simulation

### DIFF
--- a/robot_model/mmo_700/urdf/xacros/mpo_700_head.xacro
+++ b/robot_model/mmo_700/urdf/xacros/mpo_700_head.xacro
@@ -21,14 +21,14 @@
     <visual>
      <origin xyz="0 0 0.10" rpy="0 0 0"/>
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </visual>
 
     <collision>
      <origin xyz="0 0 0.10" rpy="0 0 0" />
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </collision>
    </link>
@@ -54,14 +54,14 @@
     <visual>
      <origin xyz="0 0 0.10" rpy="0 0 0"/>
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </visual>
 
     <collision>
      <origin xyz="0 0 0.10" rpy="0 0 0" />
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </collision>
    </link>
@@ -87,14 +87,14 @@
     <visual>
      <origin xyz="0 0 0.10" rpy="0 0 0"/>
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </visual>
 
     <collision>
      <origin xyz="0 0 0.10" rpy="0 0 0" />
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </collision>
    </link>
@@ -120,14 +120,14 @@
     <visual>
      <origin xyz="0 0 0.10" rpy="0 0 0"/>
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </visual>
 
     <collision>
      <origin xyz="0 0 0.10" rpy="0 0 0" />
      <geometry>
-        <mesh filename="package://neo_simulation/robots/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://neo_mpo_700/robot_model/mmo_700/meshes/MPO-700-HEAD.dae" scale="0.001 0.001 0.001"/>
      </geometry>
     </collision>
    </link>


### PR DESCRIPTION
Before the package was dependent on the neo_simulation for the mmo_700 model meshes but the packages contains already these informations